### PR TITLE
Issue8

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -99,4 +99,10 @@ group :development, :test, :profile do
   gem 'simplecov'
   gem 'coveralls'
   gem 'codeclimate-test-reporter'
+
+  gem 'awesome_print'
+  gem 'pry'
+  gem 'pry-rails'
+  gem 'pry-doc'
+  gem 'pry-stack_explorer'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -72,11 +72,14 @@ GEM
     ast (2.2.0)
     autoprefixer-rails (6.3.6)
       execjs
+    awesome_print (1.6.1)
     axiom-types (0.1.1)
       descendants_tracker (~> 0.0.4)
       ice_nine (~> 0.11.0)
       thread_safe (~> 0.3, >= 0.3.1)
     bcrypt (3.1.11)
+    binding_of_caller (0.7.2)
+      debug_inspector (>= 0.0.1)
     bootstrap-sass (3.3.6)
       autoprefixer-rails (>= 5.2.1)
       sass (>= 3.3.4)
@@ -101,6 +104,7 @@ GEM
       virtus (~> 1.0)
     codeclimate-test-reporter (0.5.0)
       simplecov (>= 0.7.1, < 1.0.0)
+    coderay (1.1.1)
     coercible (1.0.0)
       descendants_tracker (~> 0.0.1)
     coffee-rails (4.1.1)
@@ -209,6 +213,7 @@ GEM
       actionmailer (>= 3.2.13)
       json (>= 1.7.7)
       rest-client (>= 1.6.7)
+    method_source (0.8.2)
     mime-types (2.99.1)
     mimemagic (0.3.0)
     mini_portile2 (2.0.0)
@@ -235,6 +240,18 @@ GEM
     polyamorous (1.3.0)
       activerecord (>= 3.0)
     powerpack (0.1.1)
+    pry (0.10.3)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
+    pry-doc (0.8.0)
+      pry (~> 0.9)
+      yard (~> 0.8)
+    pry-rails (0.3.4)
+      pry (>= 0.9.10)
+    pry-stack_explorer (0.4.9.2)
+      binding_of_caller (>= 0.7)
+      pry (>= 0.9.11)
     puma (3.4.0)
     rack (1.6.4)
     rack-mini-profiler (0.9.9.2)
@@ -340,6 +357,7 @@ GEM
       eventmachine (~> 1.0.0)
       thin (>= 1.5, < 1.7)
     slack-notifier (1.5.1)
+    slop (3.6.0)
     spring (1.7.1)
     sprockets (3.6.0)
       concurrent-ruby (~> 1.0)
@@ -392,6 +410,7 @@ DEPENDENCIES
   activeadmin (~> 1.0.0.pre1)
   animate-rails (~> 1.0.8)
   annotate!
+  awesome_print
   bootstrap-sass (~> 3.3.4)
   bower-rails
   bullet
@@ -419,6 +438,10 @@ DEPENDENCIES
   paper_trail (~> 4.0.0)
   paperclip
   pg
+  pry
+  pry-doc
+  pry-rails
+  pry-stack_explorer
   puma
   rack-mini-profiler
   rails (~> 4.2.1)
@@ -441,4 +464,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   1.12.3
+   1.12.4

--- a/app/admin/category.rb
+++ b/app/admin/category.rb
@@ -29,7 +29,7 @@ ActiveAdmin.register Category do
   menu parent: 'Catalog', priority: 3
   permit_params do
     permitted = [:parent_id, :reference_code, :enabled, :visible, :meta_keywords,
-                 :meta_description, :show_action_name, :priority]
+                 :meta_description, :show_action_name, :priority, :image]
 
     locales = Language.pluck(:locale).map(&:to_sym)
     permitted << {name_translations: locales}
@@ -93,6 +93,7 @@ ActiveAdmin.register Category do
     tabs do
       tab t('active_admin.categories.information') do
         f.inputs t('active_admin.categories.information') do
+          f.input :image, as: :file, hint: (image_tag(category.image.url(:thumbnail)) if category.image?)
           f.input :reference_code
           f.input :parent_id,
                   label: t('activerecord.attributes.category.parent'),
@@ -125,6 +126,7 @@ ActiveAdmin.register Category do
 
   show title: proc { |p| "#{p.name}" } do
     attributes_table do
+      row :image
       row :id
       row :name
       row :parent

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -7,6 +7,10 @@
 #  enabled                        :boolean          default(FALSE)
 #  href_translations              :hstore           default({}), not null
 #  id                             :integer          not null, primary key
+#  image_content_type             :string
+#  image_file_name                :string
+#  image_file_size                :integer
+#  image_updated_at               :datetime
 #  meta_tags_translations         :hstore           default({}), not null
 #  name_translations              :hstore           default({}), not null
 #  parent_id                      :integer

--- a/app/helpers/categories_helper.rb
+++ b/app/helpers/categories_helper.rb
@@ -7,6 +7,10 @@
 #  enabled                        :boolean          default(FALSE)
 #  href_translations              :hstore           default({}), not null
 #  id                             :integer          not null, primary key
+#  image_content_type             :string
+#  image_file_name                :string
+#  image_file_size                :integer
+#  image_updated_at               :datetime
 #  meta_tags_translations         :hstore           default({}), not null
 #  name_translations              :hstore           default({}), not null
 #  parent_id                      :integer

--- a/app/helpers/shopping_orders_helper.rb
+++ b/app/helpers/shopping_orders_helper.rb
@@ -11,7 +11,7 @@
 #  customer_id               :integer
 #  extra_fields              :hstore           default({}), not null
 #  id                        :integer          not null, primary key
-#  order_num                 :integer          not null
+#  order_num                 :integer          default(0), not null
 #  shipping_address          :hstore           default({}), not null
 #  shopping_orders_status_id :integer
 #  updated_at                :datetime         not null

--- a/app/models/shopping_order.rb
+++ b/app/models/shopping_order.rb
@@ -11,7 +11,7 @@
 #  customer_id               :integer
 #  extra_fields              :hstore           default({}), not null
 #  id                        :integer          not null, primary key
-#  order_num                 :integer          not null
+#  order_num                 :integer          default(0), not null
 #  shipping_address          :hstore           default({}), not null
 #  shopping_orders_status_id :integer
 #  updated_at                :datetime         not null

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -141,7 +141,6 @@
 #                                  admin_link GET        /admin/links/:id(.:format)                                admin/links#show
 #                                             PATCH      /admin/links/:id(.:format)                                admin/links#update
 #                                             PUT        /admin/links/:id(.:format)                                admin/links#update
-#                                             DELETE     /admin/links/:id(.:format)                                admin/links#destroy
 #                 batch_action_admin_products POST       /admin/products/batch_action(.:format)                    admin/products#batch_action
 #                              admin_products GET        /admin/products(.:format)                                 admin/products#index
 #                                             POST       /admin/products(.:format)                                 admin/products#create
@@ -286,6 +285,7 @@
 #                  POST   /attachment_files(.:format)     ckeditor/attachment_files#create
 #  attachment_file DELETE /attachment_files/:id(.:format) ckeditor/attachment_files#destroy
 #
+
 
 class RouteConstraint
   def matches?(request)

--- a/db/migrate/20160901121221_add_attachment_image_to_categories.rb
+++ b/db/migrate/20160901121221_add_attachment_image_to_categories.rb
@@ -1,0 +1,11 @@
+class AddAttachmentImageToCategories < ActiveRecord::Migration
+  def self.up
+    change_table :categories do |t|
+      t.attachment :image
+    end
+  end
+
+  def self.down
+    remove_attachment :categories, :image
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160208115135) do
+ActiveRecord::Schema.define(version: 20160901121221) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -106,6 +106,10 @@ ActiveRecord::Schema.define(version: 20160208115135) do
     t.hstore   "slug_translations",              default: {},    null: false
     t.hstore   "name_translations",              default: {},    null: false
     t.hstore   "href_translations",              default: {},    null: false
+    t.string   "image_file_name"
+    t.string   "image_content_type"
+    t.integer  "image_file_size"
+    t.datetime "image_updated_at"
   end
 
   add_index "categories", ["enabled"], name: "index_categories_on_enabled", using: :btree
@@ -358,17 +362,17 @@ ActiveRecord::Schema.define(version: 20160208115135) do
 
   create_table "shopping_orders", force: :cascade do |t|
     t.integer  "customer_id"
-    t.datetime "created_at",                                                                                        null: false
-    t.datetime "updated_at",                                                                                        null: false
+    t.datetime "created_at",                                                       null: false
+    t.datetime "updated_at",                                                       null: false
     t.integer  "commerce_id"
-    t.hstore   "shipping_address",                                   default: {},                                   null: false
-    t.hstore   "billing_address",                                    default: {},                                   null: false
-    t.hstore   "billing_commerce",                                   default: {},                                   null: false
-    t.integer  "order_num",                                          default: "nextval('order_num_seq'::regclass)", null: false
+    t.hstore   "shipping_address",                                   default: {},  null: false
+    t.hstore   "billing_address",                                    default: {},  null: false
+    t.hstore   "billing_commerce",                                   default: {},  null: false
+    t.integer  "order_num",                                          default: 0,   null: false
     t.integer  "carrier_id"
-    t.decimal  "carrier_retail_price",      precision: 10, scale: 2, default: 0.0,                                  null: false
+    t.decimal  "carrier_retail_price",      precision: 10, scale: 2, default: 0.0, null: false
     t.integer  "shopping_orders_status_id"
-    t.hstore   "extra_fields",                                       default: {},                                   null: false
+    t.hstore   "extra_fields",                                       default: {},  null: false
   end
 
   add_index "shopping_orders", ["customer_id"], name: "index_shopping_orders_on_customer_id", using: :btree

--- a/test/controllers/categories_controller_test.rb
+++ b/test/controllers/categories_controller_test.rb
@@ -7,6 +7,10 @@
 #  enabled                        :boolean          default(FALSE)
 #  href_translations              :hstore           default({}), not null
 #  id                             :integer          not null, primary key
+#  image_content_type             :string
+#  image_file_name                :string
+#  image_file_size                :integer
+#  image_updated_at               :datetime
 #  meta_tags_translations         :hstore           default({}), not null
 #  name_translations              :hstore           default({}), not null
 #  parent_id                      :integer

--- a/test/controllers/shopping_orders_controller_test.rb
+++ b/test/controllers/shopping_orders_controller_test.rb
@@ -11,7 +11,7 @@
 #  customer_id               :integer
 #  extra_fields              :hstore           default({}), not null
 #  id                        :integer          not null, primary key
-#  order_num                 :integer          not null
+#  order_num                 :integer          default(0), not null
 #  shipping_address          :hstore           default({}), not null
 #  shopping_orders_status_id :integer
 #  updated_at                :datetime         not null

--- a/test/fixtures/categories.yml
+++ b/test/fixtures/categories.yml
@@ -7,6 +7,10 @@
 #  enabled                        :boolean          default(FALSE)
 #  href_translations              :hstore           default({}), not null
 #  id                             :integer          not null, primary key
+#  image_content_type             :string
+#  image_file_name                :string
+#  image_file_size                :integer
+#  image_updated_at               :datetime
 #  meta_tags_translations         :hstore           default({}), not null
 #  name_translations              :hstore           default({}), not null
 #  parent_id                      :integer

--- a/test/fixtures/shopping_orders.yml
+++ b/test/fixtures/shopping_orders.yml
@@ -11,7 +11,7 @@
 #  customer_id               :integer
 #  extra_fields              :hstore           default({}), not null
 #  id                        :integer          not null, primary key
-#  order_num                 :integer          not null
+#  order_num                 :integer          default(0), not null
 #  shipping_address          :hstore           default({}), not null
 #  shopping_orders_status_id :integer
 #  updated_at                :datetime         not null

--- a/test/models/category_test.rb
+++ b/test/models/category_test.rb
@@ -7,6 +7,10 @@
 #  enabled                        :boolean          default(FALSE)
 #  href_translations              :hstore           default({}), not null
 #  id                             :integer          not null, primary key
+#  image_content_type             :string
+#  image_file_name                :string
+#  image_file_size                :integer
+#  image_updated_at               :datetime
 #  meta_tags_translations         :hstore           default({}), not null
 #  name_translations              :hstore           default({}), not null
 #  parent_id                      :integer

--- a/test/models/shopping_order_test.rb
+++ b/test/models/shopping_order_test.rb
@@ -11,7 +11,7 @@
 #  customer_id               :integer
 #  extra_fields              :hstore           default({}), not null
 #  id                        :integer          not null, primary key
-#  order_num                 :integer          not null
+#  order_num                 :integer          default(0), not null
 #  shipping_address          :hstore           default({}), not null
 #  shopping_orders_status_id :integer
 #  updated_at                :datetime         not null


### PR DESCRIPTION
Assigns main image to categories. Category image can be added to new categories and updated through backoffice. Creates all image thumbnails for the submited Category image. Makes images available to templates using liquid tags through Category.to_liquid method. Closes #8
